### PR TITLE
Update version, contributors, and repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "console-io",
-  "version": "13.0.2",
+  "version": "13.0.2-lineaje-01",
   "author": "coderaiser <mnemonic.enemy@gmail.com> (https://github.com/coderaiser)",
   "description": "Web console",
   "bin": {
@@ -9,7 +9,7 @@
   "main": "server/index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/cloudcmd/console-io.git"
+    "url": "https://github.com/lineaje-labs-gos/console-io"
   },
   "scripts": {
     "start": "madrun start",
@@ -73,6 +73,12 @@
     "node": ">=14"
   },
   "license": "MIT",
+  "contributors": [
+    {
+      "name": "Lineaje DepFixer",
+      "email": "221268890+Lineaje-DepFixer@users.noreply.github.com"
+    }
+  ],
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
- Appended '-lineaje-01' to the version.
- Updated repository URL to point to the new repourl in lineaje-labs-gos
