### PR TITLE
Fix Dependency conflict during npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "babel-loader": "^8.0.0",
-    "clean-css-loader": "^2.0.0",
+    "clean-css-loader": "^3.0.0",
     "css-loader": "^5.0.0",
     "es6-promisify": "^6.0.0",
     "eslint": "^7.9.0",


### PR DESCRIPTION
Fix Dependency conflict during npm install by updating clean-css-loader to the next major version that supports webpack 5.x